### PR TITLE
feat: Added function to set lender

### DIFF
--- a/contracts/DebtLocker.sol
+++ b/contracts/DebtLocker.sol
@@ -110,6 +110,12 @@ contract DebtLocker is IDebtLocker, DebtLockerStorage, MapleProxiedInternals {
         emit FundsToCaptureSet(_fundsToCapture = amount_);
     }
 
+    function setPendingLender(address newLender_) override external whenProtocolNotPaused {
+        require(msg.sender == _getPoolDelegate(), "DL:SL:NOT_PD");
+
+        IMapleLoanLike(_loan).setPendingLender(newLender_);
+    }
+
     function setMinRatio(uint256 minRatio_) external override whenProtocolNotPaused {
         require(msg.sender == _getPoolDelegate(), "DL:SMR:NOT_PD");
 

--- a/contracts/DebtLocker.sol
+++ b/contracts/DebtLocker.sol
@@ -111,7 +111,7 @@ contract DebtLocker is IDebtLocker, DebtLockerStorage, MapleProxiedInternals {
     }
 
     function setPendingLender(address newLender_) override external whenProtocolNotPaused {
-        require(msg.sender == _getPoolDelegate(), "DL:SL:NOT_PD");
+        require(msg.sender == _migrator, "DL:SPL:NOT_MIGRATOR");
 
         IMapleLoanLike(_loan).setPendingLender(newLender_);
     }

--- a/contracts/DebtLockerStorage.sol
+++ b/contracts/DebtLockerStorage.sol
@@ -16,4 +16,5 @@ contract DebtLockerStorage {
     uint256 internal _minRatio;
     uint256 internal _principalRemainingAtLastClaim;
 
+    address internal _migrator;
 }

--- a/contracts/DebtLockerV4Migrator.sol
+++ b/contracts/DebtLockerV4Migrator.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity 0.8.7;
+
+import { IDebtLockerV4Migrator } from "./interfaces/IDebtLockerV4Migrator.sol";
+
+import { DebtLockerStorage } from "./DebtLockerStorage.sol";
+
+/// @title DebtLockerV4Migrator is intended to initialize the storage of a DebtLocker proxy.
+contract DebtLockerV4Migrator is IDebtLockerV4Migrator, DebtLockerStorage {
+
+    function encodeArguments(address migrator_) external pure override returns (bytes memory encodedArguments_) {
+        return abi.encode(migrator_);
+    }
+
+    function decodeArguments(bytes calldata encodedArguments_) public pure override returns (address migrator_) {
+        ( migrator_ ) = abi.decode(encodedArguments_, (address));
+    }
+
+    fallback() external {
+
+        // Taking the migrator_ address as argument for now, but ideally this would be hardcoded in the debtLocker migrator registered in the factory
+        ( address migrator_ ) = decodeArguments(msg.data);
+
+        _migrator = migrator_;
+    }
+
+}

--- a/contracts/interfaces/IDebtLocker.sol
+++ b/contracts/interfaces/IDebtLocker.sol
@@ -125,6 +125,12 @@ interface IDebtLocker is IMapleProxied {
     function setFundsToCapture(uint256 amount_) external;
 
     /**
+     * @dev   Sets the pengind lender on a maple loan
+     * @param newLender_ The address of the new lender.
+     */
+    function setPendingLender(address newLender_) external;
+
+    /**
      * @dev Called by the PoolDelegate in case of a DoS, where a user transfers small amounts of collateralAsset into the Liquidator
      *      to make `_isLiquidationActive` remain true.
      *      CALLING THIS MAY RESULT IN RECOGNIZED LOSSES IN POOL ACCOUNTING. CONSULT MAPLE TEAM FOR GUIDANCE.

--- a/contracts/interfaces/IDebtLockerV4Migrator.sol
+++ b/contracts/interfaces/IDebtLockerV4Migrator.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity 0.8.7;
+
+/// @title DebtLockerInitializer is intended to initialize the storage of a DebtLocker proxy.
+interface IDebtLockerV4Migrator {
+
+    function encodeArguments(address migrator_) external pure returns (bytes memory encodedArguments_);
+
+    function decodeArguments(bytes calldata encodedArguments_) external pure returns (address migrator_);
+
+}

--- a/contracts/interfaces/Interfaces.sol
+++ b/contracts/interfaces/Interfaces.sol
@@ -58,6 +58,8 @@ interface IMapleLoanLike {
 
     function rejectNewTerms(address refinancer_, uint256 deadline_, bytes[] calldata calls_) external;
 
+    function setPendingLender(address pendingLender_) external;
+
 }
 
 interface IPoolLike {

--- a/contracts/test/DebtLocker.t.sol
+++ b/contracts/test/DebtLocker.t.sol
@@ -670,7 +670,6 @@ contract DebtLockerTests is TestUtils {
         assertEq(debtLocker.fundsToCapture(), 100 * 10 ** 6);
     }
 
-
     function test_acl_poolDelegate_setMinRatio() external {
         MapleLoan loan = _createLoan(1_000_000, 30_000);
 

--- a/contracts/test/DebtLocker.t.sol
+++ b/contracts/test/DebtLocker.t.sol
@@ -670,6 +670,7 @@ contract DebtLockerTests is TestUtils {
         assertEq(debtLocker.fundsToCapture(), 100 * 10 ** 6);
     }
 
+
     function test_acl_poolDelegate_setMinRatio() external {
         MapleLoan loan = _createLoan(1_000_000, 30_000);
 
@@ -681,6 +682,19 @@ contract DebtLockerTests is TestUtils {
         assertTrue(    poolDelegate.try_debtLocker_setMinRatio(address(debtLocker), 100 * 10 ** 6));  // PD can set
 
         assertEq(debtLocker.minRatio(), 100 * 10 ** 6);
+    }
+
+    function test_acl_poolDelete_setPendingLender() external {
+        ( MapleLoan loan, DebtLocker debtLocker ) = _createFundAndDrawdownLoan(1_000_000, 30_000);
+
+        address newLender_ = address(2);
+
+        assertEq(loan.pendingLender(), address(0));
+
+        assertTrue(!notPoolDelegate.try_debtLocker_setPendingLender(address(debtLocker), newLender_));
+        assertTrue(    poolDelegate.try_debtLocker_setPendingLender(address(debtLocker), newLender_));
+
+        assertEq(loan.pendingLender(), newLender_);
     }
 
     function test_acl_poolDelegate_upgrade() external {

--- a/contracts/test/accounts/PoolDelegate.sol
+++ b/contracts/test/accounts/PoolDelegate.sol
@@ -39,6 +39,10 @@ contract PoolDelegate is ProxyUser {
         IDebtLocker(debtLocker_).setMinRatio(minRatio_);
     }
 
+    function debtLocker_setPendingLender(address debtLocker_, address newLender_) external {
+        IDebtLocker(debtLocker_).setPendingLender(newLender_);
+    }
+
     function debtLocker_stopLiquidation(address debtLocker_) external {
         IDebtLocker(debtLocker_).stopLiquidation();
     }
@@ -88,6 +92,10 @@ contract PoolDelegate is ProxyUser {
 
     function try_debtLocker_setMinRatio(address debtLocker_, uint256 minRatio_) external returns (bool ok_) {
         ( ok_, ) = debtLocker_.call(abi.encodeWithSelector(IDebtLocker.setMinRatio.selector, minRatio_));
+    }
+
+    function try_debtLocker_setPendingLender(address debtLocker_, address newLender_) external returns (bool ok_) {
+        ( ok_, ) = debtLocker_.call(abi.encodeWithSelector(IDebtLocker.setPendingLender.selector, newLender_));
     }
 
     function try_debtLocker_stopLiquidation(address debtLocker_) external returns (bool ok_) {


### PR DESCRIPTION
# Description

Added a function on debt locker that allows the pool delegate to call `setPendingLender` on the loan contract

# Integrations Checklist

- [ ] Have any function signatures changed? If yes, outline below.
- [ ] Have any features changed or been added? If yes, outline below.
- [ ] Have any events changed or been added? If yes, outline below.
- [ ] Has all documentation been updated?

# Changelog
## Function Signature Changes

## Features 

## Events

